### PR TITLE
Create `components` subdirectory 

### DIFF
--- a/examples/splashgen_site.py
+++ b/examples/splashgen_site.py
@@ -1,4 +1,6 @@
-from splashgen import SplashSite, CTAButton, launch
+from splashgen import launch
+from splashgen.components import SplashSite, CTAButton
+
 
 site = SplashSite(title="Splashgen - Splash Pages Built In Python",
                   theme="dark")

--- a/examples/zenweb.py
+++ b/examples/zenweb.py
@@ -1,5 +1,6 @@
 from os import path
-from splashgen import MetaTags, SplashSite, launch
+from splashgen import MetaTags, launch
+from splashgen.components import SplashSite
 from splashgen.integrations import MailchimpSignup
 
 site = SplashSite(title="ZenWeb – Python Internal Web Apps",

--- a/splashgen/__init__.py
+++ b/splashgen/__init__.py
@@ -7,11 +7,10 @@ from os import path
 from jinja2 import Environment, PackageLoader
 from PIL import Image
 
+
 jinja = Environment(loader=PackageLoader("splashgen"), autoescape=False)
 
 _assigned_component = None
-
-_ASSET_DIR = path.join(path.dirname(__file__), 'assets')
 
 
 class Component(ABC):
@@ -43,77 +42,12 @@ class Component(ABC):
         pathlib.Path(self.build_dir).mkdir(parents=True, exist_ok=True)
 
 
-class CTAButton(Component):
-    def __init__(self, link: str, text: str) -> None:
-        self.link = link
-        self.text = text
-
-    def render(self) -> str:
-        return f'<a href="{self.link}" class="btn btn-primary btn-lg px-4">{self.text}</a>'
-
-
 @dataclass
 class MetaTags:
     title: str
     description: str
     image: str
     canonical_url: str
-
-
-# TODO: Render favicons, touch icon, splash icons, etc.
-# TODO: Support BG color?
-class SplashSite(Component):
-    meta: MetaTags
-    headline: str
-    subtext: str
-    call_to_action: Component
-    enable_splashgen_analytics: bool
-    """Set this to false to disable analytics.
-
-    We use analytics in order to better understand product usage, and *never*
-    track any personally-identifiable information on users visiting your site.
-    """
-
-    def __init__(self, title: str = "Splash Site", logo: str = None, meta: MetaTags = None, theme: str = "light") -> str:
-        super().__init__()
-        self.title = title
-        if not logo:
-            logo = path.join(_ASSET_DIR, "logo-default.png")
-        self.logo = logo
-        self.meta = meta
-        if theme not in ["light", "dark"]:
-            raise ValueError(
-                "Invalid theme option. Please specify 'light' or 'dark'")
-        self.theme = theme
-        self.headline = "Fill out your headline here by assigning to `headline`"
-        self.subtext = "Fill out subtext by assigning to `subtext`"
-        self.call_to_action = None
-        self.favicon_img = self.logo
-        self.enable_splashgen_analytics = True
-
-    def render(self) -> str:
-        logo_url = self.write_asset_to_build(self.logo)
-        favicons = self._gen_favicons()
-        return self.into_template("splash_site.html.jinja", extras={
-            "logo": logo_url,
-            "favicons": favicons
-        })
-
-    def _gen_favicons(self):
-        favicons = []
-        with Image.open(self.favicon_img) as img:
-            for size in [16, 32, 64]:
-                favicon_info = {
-                    "rel": "icon",
-                    "type": "image/png",
-                    "size": f"{size}x{size}",
-                    "filename": f"favicon-{size}x{size}.png"
-                }
-                resized = img.resize((size, size))
-                resized.save(path.join(self.build_dir,
-                             favicon_info["filename"]))
-                favicons.append(favicon_info)
-        return favicons
 
 
 def launch(root: Component) -> None:

--- a/splashgen/components/CTAButton.py
+++ b/splashgen/components/CTAButton.py
@@ -1,0 +1,10 @@
+from splashgen import Component
+
+
+class CTAButton(Component):
+    def __init__(self, link: str, text: str) -> None:
+        self.link = link
+        self.text = text
+
+    def render(self) -> str:
+        return f'<a href="{self.link}" class="btn btn-primary btn-lg px-4">{self.text}</a>'

--- a/splashgen/components/SplashSite.py
+++ b/splashgen/components/SplashSite.py
@@ -1,0 +1,61 @@
+from splashgen import Component, MetaTags
+from os import path
+from PIL import Image
+
+_ASSET_DIR = path.join(path.dirname(__file__), '../assets')
+
+
+# TODO: Render favicons, touch icon, splash icons, etc.
+# TODO: Support BG color?
+class SplashSite(Component):
+    meta: MetaTags
+    headline: str
+    subtext: str
+    call_to_action: Component
+    enable_splashgen_analytics: bool
+    """Set this to false to disable analytics.
+
+    We use analytics in order to better understand product usage, and *never*
+    track any personally-identifiable information on users visiting your site.
+    """
+
+    def __init__(self, title: str = "Splash Site", logo: str = None, meta: MetaTags = None, theme: str = "light") -> str:
+        super().__init__()
+        self.title = title
+        if not logo:
+            logo = path.join(_ASSET_DIR, "logo-default.png")
+        self.logo = logo
+        self.meta = meta
+        if theme not in ["light", "dark"]:
+            raise ValueError(
+                "Invalid theme option. Please specify 'light' or 'dark'")
+        self.theme = theme
+        self.headline = "Fill out your headline here by assigning to `headline`"
+        self.subtext = "Fill out subtext by assigning to `subtext`"
+        self.call_to_action = None
+        self.favicon_img = self.logo
+        self.enable_splashgen_analytics = True
+
+    def render(self) -> str:
+        logo_url = self.write_asset_to_build(self.logo)
+        favicons = self._gen_favicons()
+        return self.into_template("splash_site.html.jinja", extras={
+            "logo": logo_url,
+            "favicons": favicons
+        })
+
+    def _gen_favicons(self):
+        favicons = []
+        with Image.open(self.favicon_img) as img:
+            for size in [16, 32, 64]:
+                favicon_info = {
+                    "rel": "icon",
+                    "type": "image/png",
+                    "size": f"{size}x{size}",
+                    "filename": f"favicon-{size}x{size}.png"
+                }
+                resized = img.resize((size, size))
+                resized.save(path.join(self.build_dir,
+                             favicon_info["filename"]))
+                favicons.append(favicon_info)
+        return favicons

--- a/splashgen/components/__init__.py
+++ b/splashgen/components/__init__.py
@@ -1,0 +1,2 @@
+from .SplashSite import SplashSite
+from .CTAButton import CTAButton


### PR DESCRIPTION
## Summary
Move components out of the __init__ folder and into a components subdirectory and update the examples

## Impact

Prepare for new components and templates 

## Test

```
python -m splashgen.cli .\examples\zenweb.py
python -m http.server --directory build  

# Produces a functioning splash page served at localhost:8000

python -m splashgen.cli .\examples\splashgen_site.py
python -m http.server --directory build

# Produces a functioning splash page served at localhost:8000
```


## Follow up after land

Include updated Readme with new images after PR is accepted 